### PR TITLE
Clean up name API

### DIFF
--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -212,7 +212,7 @@ mod tests {
             EndEntityCert::try_from(der).expect("should parse end entity certificate correctly");
 
         let mut names = cert.dns_names();
-        assert_eq!(names.next().map(<&str>::from), Some(name));
-        assert_eq!(names.next().map(<&str>::from), None);
+        assert_eq!(names.next(), Some(name));
+        assert_eq!(names.next(), None);
     }
 }

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -32,7 +32,7 @@ impl<'a> From<GeneralDnsNameRef<'a>> for &'a str {
     fn from(d: GeneralDnsNameRef<'a>) -> Self {
         match d {
             GeneralDnsNameRef::DnsName(name) => name.as_str(),
-            GeneralDnsNameRef::Wildcard(name) => name.into(),
+            GeneralDnsNameRef::Wildcard(name) => name.as_str(),
         }
     }
 }
@@ -168,6 +168,13 @@ impl<'a> WildcardDnsNameRef<'a> {
     pub fn try_from_ascii_str(dns_name: &'a str) -> Result<Self, InvalidDnsNameError> {
         Self::try_from_ascii(dns_name.as_bytes())
     }
+
+    /// Yields a reference to the DNS name as a `&str`.
+    pub fn as_str(&self) -> &'a str {
+        // The unwrap won't fail because a `WildcardDnsNameRef` is guaranteed to be ASCII and
+        // ASCII is a subset of UTF-8.
+        core::str::from_utf8(self.0).unwrap()
+    }
 }
 
 impl core::fmt::Debug for WildcardDnsNameRef<'_> {
@@ -182,23 +189,6 @@ impl core::fmt::Debug for WildcardDnsNameRef<'_> {
         }
 
         f.write_str("\")")
-    }
-}
-
-impl<'a> From<WildcardDnsNameRef<'a>> for &'a str {
-    fn from(WildcardDnsNameRef(d): WildcardDnsNameRef<'a>) -> Self {
-        // The unwrap won't fail because WildcardDnsNameRef are guaranteed to be ASCII
-        // and ASCII is a subset of UTF-8.
-        core::str::from_utf8(d).unwrap()
-    }
-}
-
-impl AsRef<str> for WildcardDnsNameRef<'_> {
-    #[inline]
-    fn as_ref(&self) -> &str {
-        // The unwrap won't fail because WildcardDnsNameRef are guaranteed to be ASCII
-        // and ASCII is a subset of UTF-8.
-        core::str::from_utf8(self.0).unwrap()
     }
 }
 

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -72,20 +72,6 @@ impl AsRef<str> for DnsNameRef<'_> {
     }
 }
 
-/// An error indicating that a `DnsNameRef` could not built because the input
-/// is not a syntactically-valid DNS Name.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct InvalidDnsNameError;
-
-impl core::fmt::Display for InvalidDnsNameError {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-#[cfg(feature = "std")]
-impl ::std::error::Error for InvalidDnsNameError {}
-
 impl<'a> DnsNameRef<'a> {
     /// Constructs a `DnsNameRef` from the given input if the input is a
     /// syntactically-valid DNS name.
@@ -227,6 +213,20 @@ impl AsRef<str> for WildcardDnsNameRef<'_> {
         core::str::from_utf8(self.0).unwrap()
     }
 }
+
+/// An error indicating that a `DnsNameRef` could not built because the input
+/// is not a syntactically-valid DNS Name.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InvalidDnsNameError;
+
+impl core::fmt::Display for InvalidDnsNameError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl ::std::error::Error for InvalidDnsNameError {}
 
 pub(super) fn presented_id_matches_reference_id(
     presented_dns_id: untrusted::Input,

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -28,11 +28,12 @@ pub enum GeneralDnsNameRef<'name> {
     Wildcard(WildcardDnsNameRef<'name>),
 }
 
-impl<'a> From<GeneralDnsNameRef<'a>> for &'a str {
-    fn from(d: GeneralDnsNameRef<'a>) -> Self {
-        match d {
-            GeneralDnsNameRef::DnsName(name) => name.as_str(),
-            GeneralDnsNameRef::Wildcard(name) => name.as_str(),
+impl<'a> GeneralDnsNameRef<'a> {
+    /// Yields the DNS name as a `&str`.
+    pub fn as_str(&self) -> &'a str {
+        match self {
+            Self::DnsName(name) => name.as_str(),
+            Self::Wildcard(name) => name.as_str(),
         }
     }
 }

--- a/src/subject_name/dns_name.rs
+++ b/src/subject_name/dns_name.rs
@@ -18,6 +18,25 @@ use core::fmt::Write;
 
 use crate::Error;
 
+/// A DNS name that may be either a DNS name identifier presented by a server (which may include
+/// wildcards), or a DNS name identifier referenced by a client for matching purposes (wildcards
+/// not permitted).
+pub enum GeneralDnsNameRef<'name> {
+    /// a reference to a DNS name that may be used for matching purposes.
+    DnsName(DnsNameRef<'name>),
+    /// a reference to a presented DNS name that may include a wildcard.
+    Wildcard(WildcardDnsNameRef<'name>),
+}
+
+impl<'a> From<GeneralDnsNameRef<'a>> for &'a str {
+    fn from(d: GeneralDnsNameRef<'a>) -> Self {
+        match d {
+            GeneralDnsNameRef::DnsName(name) => name.into(),
+            GeneralDnsNameRef::Wildcard(name) => name.into(),
+        }
+    }
+}
+
 /// A DNS Name suitable for use in the TLS Server Name Indication (SNI)
 /// extension and/or for use as the reference hostname for which to verify a
 /// certificate.
@@ -123,25 +142,6 @@ impl<'a> From<DnsNameRef<'a>> for &'a str {
         // The unwrap won't fail because DnsNameRefs are guaranteed to be ASCII
         // and ASCII is a subset of UTF-8.
         core::str::from_utf8(d).unwrap()
-    }
-}
-
-/// A DNS name that may be either a DNS name identifier presented by a server (which may include
-/// wildcards), or a DNS name identifier referenced by a client for matching purposes (wildcards
-/// not permitted).
-pub enum GeneralDnsNameRef<'name> {
-    /// a reference to a DNS name that may be used for matching purposes.
-    DnsName(DnsNameRef<'name>),
-    /// a reference to a presented DNS name that may include a wildcard.
-    Wildcard(WildcardDnsNameRef<'name>),
-}
-
-impl<'a> From<GeneralDnsNameRef<'a>> for &'a str {
-    fn from(d: GeneralDnsNameRef<'a>) -> Self {
-        match d {
-            GeneralDnsNameRef::DnsName(name) => name.into(),
-            GeneralDnsNameRef::Wildcard(name) => name.into(),
-        }
     }
 }
 

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -325,9 +325,9 @@ pub(crate) fn list_cert_dns_names<'names>(
         // if the name could be converted to a DNS name, return it; otherwise,
         // keep going.
         match DnsNameRef::try_from_ascii(presented_id.as_slice_less_safe()) {
-            Ok(dns_name) => Some(dns_name.into()),
+            Ok(dns_name) => Some(dns_name.as_str()),
             Err(_) => match WildcardDnsNameRef::try_from_ascii(presented_id.as_slice_less_safe()) {
-                Ok(wildcard_dns_name) => Some(wildcard_dns_name.into()),
+                Ok(wildcard_dns_name) => Some(wildcard_dns_name.as_str()),
                 Err(_) => None,
             },
         }

--- a/src/subject_name/verify.rs
+++ b/src/subject_name/verify.rs
@@ -24,7 +24,7 @@ pub(crate) fn verify_cert_dns_name(
     dns_name: DnsNameRef,
 ) -> Result<(), Error> {
     let cert = cert.inner();
-    let dns_name = untrusted::Input::from(dns_name.as_ref().as_bytes());
+    let dns_name = untrusted::Input::from(dns_name.as_str().as_bytes());
     NameIterator::new(Some(cert.subject), cert.subject_alt_name)
         .find_map(|result| {
             let name = match result {


### PR DESCRIPTION
This removes the `From` impls and that seems to have some interesting downstream effects in terms of making types/methods unused (I guess because the `From` impls make the types constructable from a foreign caller?).

Just layering on top of your PR probably doesn't exactly make sense -- maybe you can look at what got added for the `dns_names()` API originally and how much that we could/should revert with these changes?